### PR TITLE
fix: onRequest hook race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,10 @@ module.exports = fp(async function (fastify, opts) {
   fastify.addHook('onResponse', async (req, reply) => {
     if (ignoreRoute(req)) return
 
-    const { summaryTimer, histogramTimer } = timers.get(req)
+    const requestTimers = timers.get(req)
+    if (!requestTimers) return
+
+    const { summaryTimer, histogramTimer } = requestTimers
     timers.delete(req)
 
     if (ignore(req, reply)) return

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@platformatic/fastify-http-metrics",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@platformatic/fastify-http-metrics",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fastify-plugin": "^4.5.1",

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,8 +3,8 @@
 const { setTimeout: sleep } = require('node:timers/promises')
 const fastify = require('fastify')
 
-function createFastifyApp (t) {
-  const app = fastify()
+function createFastifyApp (opts = {}) {
+  const app = fastify(opts)
 
   app.all('/500ms', async () => {
     await sleep(500)
@@ -23,7 +23,7 @@ function createFastifyApp (t) {
 
   app.all('/dynamic_delay', async (request) => {
     const delay = request.query.delay
-    await sleep(delay)
+    await sleep(parseInt(delay))
     return 'Hello World\n'
   })
 


### PR DESCRIPTION
Fixes the case when another `onRequest` hook is executed firsts and it replies to the request.